### PR TITLE
Add enum type skeletons

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -19,6 +19,8 @@
     "prefer-const": "error",
     "no-use-before-define": "error",
     "@typescript-eslint/no-misused-promises": "off",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "prettier/prettier": [
       "error",
       {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,7 +22,7 @@
         "pg": "^8.11.5",
         "ts-node": "10.9.2",
         "typescript": "5.4.5",
-        "utility-types": "^3.11.0",
+        "utility-types": "3.11.0",
         "uuid": "9.0.1"
       },
       "devDependencies": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,7 @@
         "pg": "^8.11.5",
         "ts-node": "10.9.2",
         "typescript": "5.4.5",
+        "utility-types": "^3.11.0",
         "uuid": "9.0.1"
       },
       "devDependencies": {
@@ -3343,6 +3344,14 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/utils-merge": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
     "pg": "^8.11.5",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
-    "utility-types": "^3.11.0",
+    "utility-types": "3.11.0",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "pg": "^8.11.5",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
+    "utility-types": "^3.11.0",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/backend/src/entities/event-entity.ts
+++ b/backend/src/entities/event-entity.ts
@@ -1,5 +1,6 @@
-import { Entity, Property, ManyToOne, OneToMany } from '@mikro-orm/core';
+import { Entity, Property, Enum, ManyToOne, OneToMany } from '@mikro-orm/core';
 import { BaseEntity, UserEntity, VoteEntity, EventDetailEntity } from './index';
+import { EventTypeValues } from '../types';
 
 @Entity()
 export class EventEntity extends BaseEntity {
@@ -9,9 +10,8 @@ export class EventEntity extends BaseEntity {
   @Property()
   title: string;
 
-  // TODO: Type should be of type enum with a predefined type
-  @Property()
-  type: string;
+  @Enum()
+  type: EventTypeValues;
 
   @OneToMany(() => VoteEntity, (vote) => vote.event)
   votes = new Array<VoteEntity>();
@@ -19,7 +19,7 @@ export class EventEntity extends BaseEntity {
   @OneToMany(() => EventDetailEntity, (detail) => detail.event)
   details = new Array<EventDetailEntity>();
 
-  constructor(creator: UserEntity, title: string, type: string) {
+  constructor(creator: UserEntity, title: string, type: EventTypeValues) {
     super();
     this.creator = creator;
     this.title = title;

--- a/backend/src/entities/friend-entity.ts
+++ b/backend/src/entities/friend-entity.ts
@@ -1,5 +1,6 @@
-import { Entity, Property, ManyToOne } from '@mikro-orm/core';
+import { Entity, Enum, ManyToOne } from '@mikro-orm/core';
 import { BaseEntity, UserEntity } from './index';
+import { StatusTypeValues } from '../types';
 
 @Entity()
 export class FriendEntity extends BaseEntity {
@@ -9,11 +10,10 @@ export class FriendEntity extends BaseEntity {
   @ManyToOne(() => UserEntity)
   friend: UserEntity;
 
-  // TODO: status should be enum with its own type
-  @Property()
-  status: string;
+  @Enum()
+  status: StatusTypeValues;
 
-  constructor(user: UserEntity, friend: UserEntity, status: string) {
+  constructor(user: UserEntity, friend: UserEntity, status: StatusTypeValues) {
     super();
     this.user = user;
     this.friend = friend;

--- a/backend/src/entities/vote-entity.ts
+++ b/backend/src/entities/vote-entity.ts
@@ -1,7 +1,5 @@
 import { Entity, Property, ManyToOne } from '@mikro-orm/core';
-import { BaseEntity } from './base-entity';
-import { UserEntity } from './user-entity';
-import { EventEntity } from './event-entity';
+import { BaseEntity, UserEntity, EventEntity } from './index';
 
 @Entity()
 export class VoteEntity extends BaseEntity {

--- a/backend/src/entities/vote-entity.ts
+++ b/backend/src/entities/vote-entity.ts
@@ -1,5 +1,6 @@
-import { Entity, Property, ManyToOne } from '@mikro-orm/core';
+import { Entity, Enum, ManyToOne } from '@mikro-orm/core';
 import { BaseEntity, UserEntity, EventEntity } from './index';
+import { VoteTypeValues } from '../types';
 
 @Entity()
 export class VoteEntity extends BaseEntity {
@@ -9,11 +10,10 @@ export class VoteEntity extends BaseEntity {
   @ManyToOne(() => UserEntity)
   user: UserEntity;
 
-  //TODO: vote_type should be of type enum
-  @Property()
-  vote_type: string;
+  @Enum()
+  vote_type: VoteTypeValues;
 
-  constructor(event: EventEntity, user: UserEntity, vote_type: string) {
+  constructor(event: EventEntity, user: UserEntity, vote_type: VoteTypeValues) {
     super();
     this.event = event;
     this.user = user;

--- a/backend/src/entities/vote-entity.ts
+++ b/backend/src/entities/vote-entity.ts
@@ -11,12 +11,12 @@ export class VoteEntity extends BaseEntity {
   user: UserEntity;
 
   @Enum()
-  vote_type: VoteTypeValues;
+  type: VoteTypeValues;
 
-  constructor(event: EventEntity, user: UserEntity, vote_type: VoteTypeValues) {
+  constructor(event: EventEntity, user: UserEntity, type: VoteTypeValues) {
     super();
     this.event = event;
     this.user = user;
-    this.vote_type = vote_type;
+    this.type = type;
   }
 }

--- a/backend/src/types/event-type.ts
+++ b/backend/src/types/event-type.ts
@@ -1,0 +1,14 @@
+import { ValuesType } from 'utility-types';
+
+export enum EventType {
+  FOOTBALL = 'FOOTBALL',
+  BASKETBALL = 'BASKETBALL',
+  PADEL = 'PADEL',
+  GAME_NIGHT = 'GAME_NIGHT',
+  VIDEO_GAMES = 'VIDEO_GAMES',
+  COFFEE = 'COFFEE',
+  NIGHT_OUT = 'NIGHT_OUT',
+  FIELD_TRIP = 'FIELD_TRIP',
+}
+
+export type EventTypeValues = ValuesType<typeof EventType>;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './vote-type';
+export * from './status-type';
+export * from './event-type';

--- a/backend/src/types/status-type.ts
+++ b/backend/src/types/status-type.ts
@@ -1,0 +1,9 @@
+import { ValuesType } from 'utility-types';
+
+export enum StatusType {
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED',
+  SENT = 'SENT',
+}
+
+export type StatusTypeValues = ValuesType<typeof StatusType>;

--- a/backend/src/types/vote-type.ts
+++ b/backend/src/types/vote-type.ts
@@ -1,0 +1,9 @@
+import { ValuesType } from 'utility-types';
+
+export enum VoteType {
+  PLUS = 'PLUS',
+  MINUS = 'MINUS',
+  MAYBE = 'MAYBE',
+}
+
+export type VoteTypeValues = ValuesType<typeof VoteType>;


### PR DESCRIPTION
## TICKET SUMMARY
### Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Task
- [ ] Chore

### Description
NOTE: Must run `npm i` after pulling this PR.
This PR adds:

- `event.status` is now of type `enum`
- `vote.type` is now of type `enum`
- `event.status` is now of type `enum`
- fixed some bad naming
- introduced a utility-types package
